### PR TITLE
Added `needs_cover_resize` flag for modules that provide full-res covers

### DIFF
--- a/orpheus/music_downloader.py
+++ b/orpheus/music_downloader.py
@@ -50,7 +50,7 @@ class Downloader:
         
         if playlist_info.cover_url:
             self.print('Downloading playlist cover')
-            download_file(playlist_info.cover_url, f'{playlist_path}Cover.{playlist_info.cover_type.name}')
+            download_file(playlist_info.cover_url, f'{playlist_path}Cover.{playlist_info.cover_type.name}', artwork_settings=self._get_artwork_settings())
         
         if playlist_info.animated_cover_url and self.global_settings['covers']['save_animated_cover']:
             self.print('Downloading animated playlist cover')
@@ -122,7 +122,7 @@ class Downloader:
     def _download_album_files(self, album_path: str, album_info: AlbumInfo):
         if album_info.cover_url:
             self.print('Downloading album cover')
-            download_file(album_info.cover_url, f'{album_path}Cover.{album_info.cover_type.name}')
+            download_file(album_info.cover_url, f'{album_path}Cover.{album_info.cover_type.name}', artwork_settings=self._get_artwork_settings())
 
         if album_info.animated_cover_url and self.global_settings['covers']['save_animated_cover']:
             self.print('Downloading animated album cover')
@@ -369,20 +369,20 @@ class Downloader:
                         if rms < rms_threshold:
                             self.print('Match found below threshold ' + str(rms_threshold))
                             jpg_cover_info: CoverInfo = cover_module.get_track_cover(r.result_id, jpg_cover_options, **r.extra_kwargs)
-                            download_file(jpg_cover_info.url, cover_temp_location)
+                            download_file(jpg_cover_info.url, cover_temp_location, artwork_settings=self._get_artwork_settings(covers_module_name))
                             silentremove(default_temp)
                             if self.global_settings['covers']['save_external']:
                                 ext_cover_info: CoverInfo = cover_module.get_track_cover(r.result_id, ext_cover_options, **r.extra_kwargs)
-                                download_file(ext_cover_info.url, f'{track_location_name}.{ext_cover_info.file_type.name}')
+                                download_file(ext_cover_info.url, f'{track_location_name}.{ext_cover_info.file_type.name}', artwork_settings=self._get_artwork_settings(covers_module_name, is_external=True))
                             break
                 else:
                     self.print('Third-party module could not find cover, using fallback')
                     shutil.move(default_temp, cover_temp_location)
             else:
-                download_file(track_info.cover_url, cover_temp_location)
+                download_file(track_info.cover_url, cover_temp_location, artwork_settings=self._get_artwork_settings())
                 if self.global_settings['covers']['save_external'] and ModuleModes.covers in self.module_settings[self.service_name].module_supported_modes:
                     ext_cover_info: CoverInfo = self.service.get_track_cover(track_id, ext_cover_options, **track_info.cover_extra_kwargs)
-                    download_file(ext_cover_info.url, f'{track_location_name}.{ext_cover_info.file_type.name}')
+                    download_file(ext_cover_info.url, f'{track_location_name}.{ext_cover_info.file_type.name}', artwork_settings=self._get_artwork_settings(is_external=True))
 
         if track_info.animated_cover_url and self.global_settings['covers']['save_animated_cover']:
             self.print('Downloading animated cover')
@@ -553,3 +553,13 @@ class Downloader:
             silentremove(cover_temp_location)
         
         self.print(f'=== Track {track_id} downloaded ===', drop_level=1)
+
+    def _get_artwork_settings(self, module_name = None, is_external = False):
+        if not module_name:
+            module_name = self.service_name
+        return {
+            'should_resize': ModuleFlags.needs_cover_resize in self.module_settings[module_name].flags,
+            'resolution': self.global_settings['covers']['external_resolution'] if is_external else self.global_settings['covers']['main_resolution'],
+            'compression': self.global_settings['covers']['external_compression'] if is_external else self.global_settings['covers']['main_compression'],
+            'format': self.global_settings['covers']['external_format'] if is_external else 'jpg'
+        }

--- a/utils/models.py
+++ b/utils/models.py
@@ -134,6 +134,7 @@ class ModuleFlags(Flag):
     enable_jwt_system = auto()
     private = auto()
     uses_data = auto()
+    needs_cover_resize = auto()
 
 
 class ModuleModes(Flag):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -33,7 +33,7 @@ def fix_file_limit(path: str, file_limit=250):
 
 r_session = create_requests_session()
 
-def download_file(url, file_location, headers={}, enable_progress_bar=False, indent_level=0):
+def download_file(url, file_location, headers={}, enable_progress_bar=False, indent_level=0, artwork_settings=None):
     if os.path.isfile(file_location):
         return None
 
@@ -62,6 +62,19 @@ def download_file(url, file_location, headers={}, enable_progress_bar=False, ind
                 bar.close()
             else:
                 [f.write(chunk) for chunk in r.iter_content(chunk_size=1024) if chunk]
+        if artwork_settings and artwork_settings.get('should_resize', False):
+            new_resolution = artwork_settings.get('resolution', 1400)
+            new_format = artwork_settings.get('format', 'jpeg')
+            if new_format == 'jpg': new_format = 'jpeg'
+            new_compression = artwork_settings.get('compression', 'low')
+            if new_compression == 'low':
+                new_compression = 90
+            elif new_compression == 'high':
+                new_compression = 70
+            if new_format == 'png': new_compression = None
+            with Image.open(file_location) as im:
+                im = im.resize((new_resolution, new_resolution), Image.Resampling.BICUBIC)
+                im.save(file_location, new_format, quality=new_compression)
     except KeyboardInterrupt:
         if os.path.isfile(file_location):
             print(f'\tDeleting partially downloaded file "{str(file_location)}"')


### PR DESCRIPTION
Fixes incorrect cover sizes for modules like qobuz by just adding `needs_cover_resize` flag to the modules that needs it.
This will not change anything during download if the flag is not added to the module.