### PR TITLE
Fix drive letters for Windows

### DIFF
--- a/orpheus.py
+++ b/orpheus.py
@@ -93,7 +93,7 @@ def main():
         else:
             raise Exception(f'Unknown module {module}') # TODO: replace with InvalidModuleError
     else:
-        path = args.output if args.output else orpheus.settings['global']['general']['download_path']
+        path = args.output if args.output else os.path.abspath(orpheus.settings['global']['general']['download_path'])
         if path[-1] == '/': path = path[:-1]  # removes '/' from end if it exists
         os.makedirs(path, exist_ok=True)
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -24,7 +24,7 @@ sanitise_name = lambda name : re.sub(r'[:]', ' - ', re.sub(r'[\\/*?"<>|$]', '', 
 
 def fix_file_limit(path: str, file_limit=250):
     # only needs the relative path, the abspath uses already existing folders
-    rel_path = os.path.relpath(path).replace('\\', '/')
+    rel_path = os.path.abspath(path).replace('\\', '/')
     # iterate over all folders and file and check for a file_limit violation
     split_path = [folder[:file_limit] if len(folder) > file_limit else folder for folder in rel_path.split('/')]
     # join the split_path together


### PR DESCRIPTION
This fixes an issue where if a drive letter is used, Orpheus errors out #19. Not yet tested on Linux but it should work just fine. 