### PR TITLE
Refactor fix_file_limit to fix_byte_limit

### DIFF
--- a/orpheus/music_downloader.py
+++ b/orpheus/music_downloader.py
@@ -79,8 +79,8 @@ class Downloader:
         playlist_tags = {k: sanitise_name(v) for k, v in asdict(playlist_info).items()}
         playlist_tags['explicit'] = ' [E]' if playlist_info.explicit else ''
         playlist_path = self.path + self.global_settings['formatting']['playlist_format'].format(**playlist_tags)
-        # fix path character limit
-        playlist_path = fix_file_limit(playlist_path) + '/'
+        # fix path byte limit
+        playlist_path = fix_byte_limit(playlist_path) + '/'
         os.makedirs(playlist_path, exist_ok=True)
         
         if playlist_info.cover_url:
@@ -182,8 +182,8 @@ class Downloader:
         album_tags['artist_initials'] = self._get_artist_initials_from_name(album_info)
 
         album_path = path + self.global_settings['formatting']['album_format'].format(**album_tags)
-        # fix path character limit
-        album_path = fix_file_limit(album_path) + '/'
+        # fix path byte limit
+        album_path = fix_byte_limit(album_path) + '/'
         os.makedirs(album_path, exist_ok=True)
 
         return album_path
@@ -355,8 +355,8 @@ class Downloader:
         else:
             if track_info.tags.total_discs and track_info.tags.total_discs > 1: album_location += f'CD {track_info.tags.disc_number!s}/'
             track_location_name = album_location + self.global_settings['formatting']['track_filename_format'].format(**track_tags)
-        # fix file and path character limit
-        track_location_name = fix_file_limit(track_location_name)
+        # fix file byte limit
+        track_location_name = fix_byte_limit(track_location_name)
         os.makedirs(track_location_name[:track_location_name.rfind('/')], exist_ok=True)
 
         try:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -22,13 +22,20 @@ def create_requests_session():
 sanitise_name = lambda name : re.sub(r'[:]', ' - ', re.sub(r'[\\/*?"<>|$]', '', re.sub(r'[ \t]+$', '', str(name).rstrip()))) if name else ''
 
 
-def fix_file_limit(path: str, file_limit=250):
+def fix_byte_limit(path: str, byte_limit=250):
     # only needs the relative path, the abspath uses already existing folders
     rel_path = os.path.relpath(path).replace('\\', '/')
-    # iterate over all folders and file and check for a file_limit violation
-    split_path = [folder[:file_limit] if len(folder) > file_limit else folder for folder in rel_path.split('/')]
-    # join the split_path together
-    return '/'.join(split_path)
+
+    # split path into directory and filename
+    directory, filename = os.path.split(rel_path)
+
+    # truncate filename if its byte size exceeds the byte_limit
+    filename_bytes = filename.encode('utf-8')
+    fixed_bytes = filename_bytes[:byte_limit]
+    fixed_filename = fixed_bytes.decode('utf-8', 'ignore')
+
+    # join the directory and truncated filename together
+    return directory + '/' + fixed_filename
 
 
 r_session = create_requests_session()


### PR DESCRIPTION
### Why
- Most filesystems use 255 bytes as the max filename length. The current fix_file_limit function however, will not work on Linux because it's using the length in characters.
- We should use the byte size for cross-platform compatibility.

### What Changed?
Refactor of fix_file_limit to fix_byte_limit. 
 - Use UTF-8 for cross-platform compatibility.
 - If name is too long, truncate it!
 - We call the function at album, title and playlist creation. No need to iterate over every folder in relative path, we already checked them at creation.
 - Fixes issue #6 