### PR TITLE
Update core.py

### DIFF
--- a/orpheus/core.py
+++ b/orpheus/core.py
@@ -404,4 +404,8 @@ def orpheus_core_download(orpheus_session: Orpheus, media_to_download, third_par
                 else:
                     raise Exception(f'\tUnknown media type "{mediatype}"')
 
-    if os.path.exists('temp'): shutil.rmtree('temp')
+    if os.path.exists('temp'):
+        if not os.listdir('temp'): # Only if the temporary directory is empty
+            shutil.rmtree('temp') # Remove temporary directory
+        else:
+            print(f'=== The temporary folder is not empty ==={os.linesep}=== The temporary folder will not be deleted ==={os.linesep}=== Another instance of OrpheusDL is likely running ===')


### PR DESCRIPTION
The temporary folder gets deleted when orpheus_core_download finishes running.
However, the temporary folder is in use if another instance of orpheusdl is running.

In order to prevent interfering with another running instance, here is a proposed check to see if the 'temp' directory is empty and to only delete 'temp' if it is empty.
Also added a print acknowledgement (in the same style as other messages) to display if the 'temp' directory is not empty and is not deleted, .