### PR TITLE
Add UUID to 'temp' folder Fixes #28

### DIFF
--- a/orpheus/core.py
+++ b/orpheus/core.py
@@ -357,9 +357,9 @@ class Orpheus:
 
 def orpheus_core_download(orpheus_session: Orpheus, media_to_download, third_party_modules, separate_download_module, output_path):
     downloader = Downloader(orpheus_session.settings['global'], orpheus_session.module_controls, oprinter, output_path)
-    UUID = os.urandom(5).hex()
-    share_UUID(UUID)
-    os.makedirs(f'temp{UUID}', exist_ok=True)
+    temp_UUID = f'temp{os.urandom(5).hex()}'
+    share_temp_UUID(temp_UUID)
+    os.makedirs(temp_UUID, exist_ok=True)
 
     for mainmodule, items in media_to_download.items():
         for media in items:
@@ -406,4 +406,4 @@ def orpheus_core_download(orpheus_session: Orpheus, media_to_download, third_par
                 else:
                     raise Exception(f'\tUnknown media type "{mediatype}"')
 
-    if os.path.exists(f'temp{UUID}'): shutil.rmtree(f'temp{UUID}')
+    if os.path.exists(temp_UUID): shutil.rmtree(temp_UUID)

--- a/orpheus/core.py
+++ b/orpheus/core.py
@@ -357,7 +357,9 @@ class Orpheus:
 
 def orpheus_core_download(orpheus_session: Orpheus, media_to_download, third_party_modules, separate_download_module, output_path):
     downloader = Downloader(orpheus_session.settings['global'], orpheus_session.module_controls, oprinter, output_path)
-    os.makedirs('temp', exist_ok=True)
+    UUID = os.urandom(5).hex()
+    share_UUID(UUID)
+    os.makedirs(f'temp{UUID}', exist_ok=True)
 
     for mainmodule, items in media_to_download.items():
         for media in items:
@@ -404,4 +406,4 @@ def orpheus_core_download(orpheus_session: Orpheus, media_to_download, third_par
                 else:
                     raise Exception(f'\tUnknown media type "{mediatype}"')
 
-    if os.path.exists('temp'): shutil.rmtree('temp')
+    if os.path.exists(f'temp{UUID}'): shutil.rmtree(f'temp{UUID}')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -146,11 +146,11 @@ def set_temporary_setting(settings_location, module, root_setting, setting=None,
         session[root_setting] = value
     pickle.dump(temporary_settings, open(settings_location, 'wb'))
 
-def share_UUID(UUID_value):
-    global UUID
-    UUID = UUID_value
+def share_temp_UUID(UUID_value):
+    global temp_UUID
+    temp_UUID = UUID_value
 
-create_temp_filename = lambda : f'temp{UUID}/{os.urandom(16).hex()}'
+create_temp_filename = lambda : f'{temp_UUID}/{os.urandom(16).hex()}'
 
 def save_to_temp(input: bytes):
     location = create_temp_filename()

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -107,7 +107,7 @@ def silentremove(filename):
 def read_temporary_setting(settings_location, module, root_setting=None, setting=None, global_mode=False):
     temporary_settings = pickle.load(open(settings_location, 'rb'))
     module_settings = temporary_settings['modules'][module] if module in temporary_settings['modules'] else None
-    
+
     if module_settings:
         if global_mode:
             session = module_settings
@@ -122,7 +122,7 @@ def read_temporary_setting(settings_location, module, root_setting=None, setting
         else:
             return session[root_setting] if root_setting in session else None
     elif root_setting and not session:
-        raise Exception('Module does not use temporary settings') 
+        raise Exception('Module does not use temporary settings')
     else:
         return session
 
@@ -146,7 +146,11 @@ def set_temporary_setting(settings_location, module, root_setting, setting=None,
         session[root_setting] = value
     pickle.dump(temporary_settings, open(settings_location, 'wb'))
 
-create_temp_filename = lambda : f'temp/{os.urandom(16).hex()}'
+def share_UUID(UUID_value):
+    global UUID
+    UUID = UUID_value
+
+create_temp_filename = lambda : f'temp{UUID}/{os.urandom(16).hex()}'
 
 def save_to_temp(input: bytes):
     location = create_temp_filename()


### PR DESCRIPTION
The temporary folder gets deleted when orpheus_core_download finishes running. However, the temporary folder will be used by any other instance of orpheusdl that is also running. The deletion of this folder will interfere with other instances.

In order to prevent interference with other running instances of orpheusdl, here is a proposed change to create the temporary folder with a folder id unique to that instance.